### PR TITLE
docs: fix Lua array brackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ results try disabling it.
 ```lua
 require'cmp_zsh'.setup {
   zshrc = true, -- Source the zshrc (adding all custom completions). default: false
-  filetypes = ["deoledit", "zsh"] -- Filetypes to enable cmp_zsh source. default: ["*"]
+  filetypes = { "deoledit", "zsh" } -- Filetypes to enable cmp_zsh source. default: {"*"}
 }
 ```
 


### PR DESCRIPTION
I think `filetypes` is an array of lua.
Therefore, I update it to use `{}` instead of `[]`.
