### PR TITLE
fix: enable config.zshrc

### DIFF
--- a/lua/cmp_zsh.lua
+++ b/lua/cmp_zsh.lua
@@ -21,7 +21,7 @@ M.setup = function(opts)
   M.config = opts
 
   local script = opts.zshrc and 'cmp_capture_zshrc.zsh' or 'cmp_capture.zsh'
-  capture_script_path = capture_script_path_base .. script
+  M.capture_script_path = capture_script_path_base .. script
 end
 
 M.new = function()


### PR DESCRIPTION
The path is stored in the global variable capture_script_path, but when referring to it, self.capture_script_path is referenced.
Therefore, this PR change the destination of the path to M's local variable.

This PR makes the following modifications
1. `config.zshrc = true` is reflected in the operation
2. do not define unnecessary global variables
