### PR TITLE
doc: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ EOF
 
 ## Configuration
 
-It saves compdump file in `$COMPE_ZSH_CACHE_DIR` or `$XDG_CACHE_HOME` or
+It saves compdump file in `$CMP_ZSH_CACHE_DIR` or `$XDG_CACHE_HOME` or
 `$HOME/.cache` directory.
 
 In order to show completions defined in your zshrc you can setup cmp zsh like this.


### PR DESCRIPTION
[The source code](https://github.com/tamago324/cmp-zsh/blob/main/bin/cmp_capture_shared.zsh#L16-L25) implements CMP_ZSH_CACHE_DIR, but README.md describes COMPE_ZSH_CACHE_DIR.
Therefore, this PR fixed README.md.

fix #4