### PR TITLE
Ability to pass environment variables to scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ results try disabling it.
 ```lua
 require'cmp_zsh'.setup {
   zshrc = true, -- Source the zshrc (adding all custom completions). default: false
-  filetypes = { "deoledit", "zsh" } -- Filetypes to enable cmp_zsh source. default: {"*"}
+  filetypes = { "deoledit", "zsh" }, -- Filetypes to enable cmp_zsh source. default: {"*"}
+  env = {}, -- Environment variables to set when running the completion scripts. default: {}
 }
 ```
 

--- a/bin/cmp_capture_zshrc.zsh
+++ b/bin/cmp_capture_zshrc.zsh
@@ -6,7 +6,7 @@ zmodload zsh/zpty || { echo 'error: missing module zsh/zpty' >&2; exit 1 }
 zpty z zsh -i
 
 # Disable history for commands starting with a space
-zpty -w z ' setopt histignorespace'
+zpty -w z ' setopt histignorespace' &> /dev/null
 
 # line buffer for pty output
 local line

--- a/lua/cmp_zsh.lua
+++ b/lua/cmp_zsh.lua
@@ -13,6 +13,7 @@ local M = {
     zshrc = false,
     filetypes = {"*"},
   },
+  env = {},
   capture_script_path = capture_script_path_base .. 'cmp_capture.zsh'
 }
 
@@ -83,7 +84,8 @@ M.complete = function(self, request, callback)
   do
     local spawn_params = {
       args = { self.capture_script_path, q },
-      stdio = stdioe
+      stdio = stdioe,
+      env = self.env,
     }
 
     handle, pid = luv.spawn('zsh', spawn_params, function(code, signal)


### PR DESCRIPTION
Thank you for coming up with this solution it is a real nice thing to have.

This pull request adds ability to add environment variables to zsh scripts where you can pass some variables to disable some functionality while using zshrc or even to just use another zshrc file.